### PR TITLE
added line to return framerate for kivy backend

### DIFF
--- a/myrmidon/Game.py
+++ b/myrmidon/Game.py
@@ -283,10 +283,13 @@ class Game(object):
         cls.engine['gfx'].draw_entities(cls.entity_draw_list)
         cls.engine['gfx'].update_screen_post()
 
-        # Wait for next frame, hitting a particular fps
-        cls.current_fps = int(cls.clock.get_fps())
-        cls.clock.tick(cls.target_fps)
+        # Hack - we assume a window backend will *either* return a non-zero fps value from the clock object
+        # *or* have provided a non-zero time delta value, depending on how the main loop is handled
+        clock_fps = int(cls.clock.get_fps())
+        cls.current_fps = clock_fps if dt == 0 else 1.0/dt
 
+        # Wait for next frame, hitting a particular fps
+        cls.clock.tick(cls.target_fps)
 
     @classmethod
     def change_resolution(cls, resolution):


### PR DESCRIPTION
Added line to return framerate for kivy backend, although seems to be highly inaccurate. For `target_fps=30`, the framerate reports to fluctuate between 25 and 33. For `target_fps=60` it seems to be more stable. This may be a limitation of Kivy's timing. Fixes #43 